### PR TITLE
fix: use raw scores in prediction_buffer for patience filter

### DIFF
--- a/nanowakeword/interpreter/nanointerpreter.py
+++ b/nanowakeword/interpreter/nanointerpreter.py
@@ -180,7 +180,7 @@ class NanoInterpreter:
 
         # Update Buffers and Final State 
         for mdl_name, score in final_predictions.items():
-            self.prediction_buffer[mdl_name].append(score)
+            self.prediction_buffer[mdl_name].append(self.raw_scores[mdl_name])
             self.post_processed_scores[mdl_name] = score
             
         return self.post_processed_scores


### PR DESCRIPTION
Bug: prediction_buffer stores post-processed scores (already zeroed by VAD and patience filtering), so the patience filter never sees enough consecutive above-threshold frames — it checks a buffer full of its own filtered zeros.

Fix: Store self.raw_scores[mdl_name] in the buffer instead of the filtered score, so patience evaluates real model output. Callers still get filtered results via post_processed_scores.